### PR TITLE
Add maximum concurrent reconciles command-line option to provider executable

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -36,6 +36,7 @@ func main() {
 		app            = kingpin.New(filepath.Base(os.Args[0]), "Azure support for Crossplane.").DefaultEnvars()
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncPeriod     = app.Flag("sync", "Controller manager sync period such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
+		concurrency    = app.Flag("concurrent-reconciles", "Maximum number of concurrent reconciles which can be run per resource.").Short('c').Default("1").Int()
 		leaderElection = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -63,6 +64,6 @@ func main() {
 
 	rl := ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add Azure APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, rl), "Cannot setup Azure controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, log, rl, *concurrency), "Cannot setup Azure controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -33,11 +33,12 @@ import (
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := providerconfig.ControllerName(v1alpha1.ProviderConfigGroupKind)
 
 	o := controller.Options{
-		RateLimiter: ratelimiter.NewDefaultManagedRateLimiter(rl),
+		RateLimiter:             ratelimiter.NewDefaultManagedRateLimiter(rl),
+		MaxConcurrentReconciles: concurrency,
 	}
 
 	of := resource.ProviderConfigKinds{

--- a/internal/controller/kubernetes/kubernetescluster/zz_controller.go
+++ b/internal/controller/kubernetes/kubernetescluster/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles KubernetesCluster managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.KubernetesClusterGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.KubernetesClusterGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.KubernetesCluster{}).
 		Complete(r)
 }

--- a/internal/controller/kubernetes/kubernetesclusternodepool/zz_controller.go
+++ b/internal/controller/kubernetes/kubernetesclusternodepool/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles KubernetesClusterNodePool managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.KubernetesClusterNodePoolGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.KubernetesClusterNodePoolGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.KubernetesClusterNodePool{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualdesktopapplication/zz_controller.go
+++ b/internal/controller/virtual/virtualdesktopapplication/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualDesktopApplication managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualDesktopApplicationGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualDesktopApplicationGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualDesktopApplication{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualdesktophostpool/zz_controller.go
+++ b/internal/controller/virtual/virtualdesktophostpool/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualDesktopHostPool managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualDesktopHostPoolGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualDesktopHostPoolGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualDesktopHostPool{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualdesktopworkspace/zz_controller.go
+++ b/internal/controller/virtual/virtualdesktopworkspace/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualDesktopWorkspace managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualDesktopWorkspaceGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualDesktopWorkspaceGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualDesktopWorkspace{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualdesktopworkspaceapplicationgroupassociation/zz_controller.go
+++ b/internal/controller/virtual/virtualdesktopworkspaceapplicationgroupassociation/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualDesktopWorkspaceApplicationGroupAssociation managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualDesktopWorkspaceApplicationGroupAssociationGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualDesktopWorkspaceApplicationGroupAssociationGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualDesktopWorkspaceApplicationGroupAssociation{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualhub/zz_controller.go
+++ b/internal/controller/virtual/virtualhub/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualHub managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualHubGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualHubGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualHub{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualhubbgpconnection/zz_controller.go
+++ b/internal/controller/virtual/virtualhubbgpconnection/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualHubBgpConnection managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualHubBgpConnectionGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualHubBgpConnectionGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualHubBgpConnection{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualhubconnection/zz_controller.go
+++ b/internal/controller/virtual/virtualhubconnection/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualHubConnection managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualHubConnectionGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualHubConnectionGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualHubConnection{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualhubip/zz_controller.go
+++ b/internal/controller/virtual/virtualhubip/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualHubIp managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualHubIpGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualHubIpGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualHubIp{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualhubroutetable/zz_controller.go
+++ b/internal/controller/virtual/virtualhubroutetable/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualHubRouteTable managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualHubRouteTableGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualHubRouteTableGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualHubRouteTable{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualhubsecuritypartnerprovider/zz_controller.go
+++ b/internal/controller/virtual/virtualhubsecuritypartnerprovider/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualHubSecurityPartnerProvider managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualHubSecurityPartnerProviderGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualHubSecurityPartnerProviderGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualHubSecurityPartnerProvider{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualmachine/zz_controller.go
+++ b/internal/controller/virtual/virtualmachine/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualMachine managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualMachineGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualMachineGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualMachine{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualmachineconfigurationpolicyassignment/zz_controller.go
+++ b/internal/controller/virtual/virtualmachineconfigurationpolicyassignment/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualMachineConfigurationPolicyAssignment managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualMachineConfigurationPolicyAssignmentGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualMachineConfigurationPolicyAssignmentGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualMachineConfigurationPolicyAssignment{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualmachinedatadiskattachment/zz_controller.go
+++ b/internal/controller/virtual/virtualmachinedatadiskattachment/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualMachineDataDiskAttachment managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualMachineDataDiskAttachmentGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualMachineDataDiskAttachmentGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualMachineDataDiskAttachment{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualmachineextension/zz_controller.go
+++ b/internal/controller/virtual/virtualmachineextension/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualMachineExtension managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualMachineExtensionGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualMachineExtensionGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualMachineExtension{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualmachinescaleset/zz_controller.go
+++ b/internal/controller/virtual/virtualmachinescaleset/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualMachineScaleSet managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualMachineScaleSetGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualMachineScaleSetGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualMachineScaleSet{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualmachinescalesetextension/zz_controller.go
+++ b/internal/controller/virtual/virtualmachinescalesetextension/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualMachineScaleSetExtension managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualMachineScaleSetExtensionGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualMachineScaleSetExtensionGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualMachineScaleSetExtension{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualnetwork/zz_controller.go
+++ b/internal/controller/virtual/virtualnetwork/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualNetwork managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualNetworkGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualNetworkGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualNetwork{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualnetworkdnsservers/zz_controller.go
+++ b/internal/controller/virtual/virtualnetworkdnsservers/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualNetworkDnsServers managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualNetworkDnsServersGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualNetworkDnsServersGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualNetworkDnsServers{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualnetworkgateway/zz_controller.go
+++ b/internal/controller/virtual/virtualnetworkgateway/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualNetworkGateway managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualNetworkGatewayGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualNetworkGatewayGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualNetworkGateway{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualnetworkgatewayconnection/zz_controller.go
+++ b/internal/controller/virtual/virtualnetworkgatewayconnection/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualNetworkGatewayConnection managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualNetworkGatewayConnectionGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualNetworkGatewayConnectionGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualNetworkGatewayConnection{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualnetworkpeering/zz_controller.go
+++ b/internal/controller/virtual/virtualnetworkpeering/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualNetworkPeering managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualNetworkPeeringGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualNetworkPeeringGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualNetworkPeering{}).
 		Complete(r)
 }

--- a/internal/controller/virtual/virtualwan/zz_controller.go
+++ b/internal/controller/virtual/virtualwan/zz_controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 // Setup adds a controller that reconciles VirtualWan managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.VirtualWanGroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.VirtualWanGroupVersionKind),
@@ -45,7 +45,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&v1alpha1.VirtualWan{}).
 		Complete(r)
 }

--- a/internal/controller/zz_setup.go
+++ b/internal/controller/zz_setup.go
@@ -51,8 +51,8 @@ import (
 
 // Setup creates all controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, concurrency int) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, int) error{
 		config.Setup,
 		kubernetescluster.Setup,
 		kubernetesclusternodepool.Setup,
@@ -79,7 +79,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter) error {
 		virtualnetworkpeering.Setup,
 		virtualwan.Setup,
 	} {
-		if err := setup(mgr, l, wl); err != nil {
+		if err := setup(mgr, l, wl, concurrency); err != nil {
 			return err
 		}
 	}

--- a/scripts/prepare_azurerm.sh
+++ b/scripts/prepare_azurerm.sh
@@ -17,11 +17,13 @@
 set -eu
 
 REPO_DIR="${WORK_DIR}/.azurerm"
-rm -fR "${REPO_DIR}"
 mkdir -p "${REPO_DIR}"
 
-git -C "${REPO_DIR}" init --initial-branch=trunk
-git -C "${REPO_DIR}" remote add origin https://github.com/hashicorp/terraform-provider-azurerm
+if [ ! -d "${REPO_DIR}/.git" ]; then
+  git -C "${REPO_DIR}" init --initial-branch=trunk
+  git -C "${REPO_DIR}" remote add origin https://github.com/hashicorp/terraform-provider-azurerm
+fi
+
 git -C "${REPO_DIR}" fetch origin "${AZURERM_REFSPEC}"
 git -C "${REPO_DIR}" reset --hard FETCH_HEAD
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a change in provider-tf-azure that allows the maximum concurrent reconciles options for the controllers to be set as a command-line option. The default values stay unmodified at 1. 
Depends on https://github.com/crossplane-contrib/terrajet/pull/67.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
Manually tested this in the scope of the scalability tests I'm running with #55. I will provide more context and a detailed discussion there for the motivation behind this PR.